### PR TITLE
Configfile

### DIFF
--- a/scan_astroph/config.py
+++ b/scan_astroph/config.py
@@ -1,12 +1,87 @@
 """Read configuration files"""
 
 import json
+import os
+from configparser import ConfigParser
+from pathlib import Path
 
 
-def read_keywords(filename='keywords.txt'):
-    with open(filename) as json_file:
-        keywords = json.load(json_file)
-    return keywords
+class Config:
+    """configparser.ConfigParser wrapper with type conversion
 
-TITLE_KEYWORDS = read_keywords()
-AUTHORS = read_keywords('authors.txt')
+    Internally stores the configuration in a configparser.Configparser object,
+    but adds method for accessing keywords and authors with the right types, as
+    configparser only uses `str`
+    """
+
+    def __init__(self):
+        self._config = ConfigParser()
+
+        self._config["keywords"] = {}
+        self._config["authors"] = {}
+
+    @property
+    def keywords(self) -> dict:
+        """Get keywords/rating as dict with type `dict[str,int]`"""
+        return {keyword: int(rating) for keyword, rating in self._config["keywords"].items()}
+
+    def add_keyword(self, keyword: str, rating: int):
+        """Add keyword with rating to config"""
+        self._config["keywords"][keyword] = str(rating)
+
+    @property
+    def authors(self):
+        """Get authors/rating as dict with type `dict[str,int]`"""
+        return {author: int(rating) for author, rating in self._config["authors"].items()}
+
+    def add_author(self, author: str, rating: int):
+        """Add author with rating to config"""
+        self._config["authors"][author] = str(rating)
+
+    def read(self, path: Path):
+        """Read path to config. Existing values will be overwritten"""
+        self._config.read(path)
+
+    def write(self, path: Path, overwrite: bool = False):
+        """Write config to file. Will not overwrite existing files if `overwrite` is false"""
+        with open(path, "w" if overwrite else "x") as f:
+            self._config.write(f)
+
+
+def find_configfile():
+    """Finds location of configuration file"""
+    # Check environment variable
+    if "SCAN_ASTRO_PH_CONF" in os.environ:
+        return Path(os.path.expandvars(os.environ["SCAN_ASTRO_PH_CONF"]))
+
+    # check home directory
+    configpath = Path.home() / ".scan_astro-ph.conf"
+    if configpath.is_file():
+        return configpath
+
+    # CHECK $XDG_CONFIG_HOME
+    if "XDG_CONFIG_HOME" in os.environ:
+        configpath = Path(os.environ["XDG_CONFIG_HOME"]) / "scan_astro-ph.conf"
+    else:
+        configpath = Path.home() / ".config" / "scan_astro-ph.conf"
+    if configpath.is_file():
+        return configpath
+    else:
+        raise FileNotFoundError("Cannot find configuration file")
+
+
+def load_config_legacy_format(keywords_path: Path, authors_path: Path) -> Config:
+    """Load config from legacy format (seperate JSON files for keywords and authors"""
+    config = Config()
+
+    with open(keywords_path) as f:
+        keywords = json.load(f)
+    for keyword, rating in keywords.items():
+        config.add_keyword(keyword, rating)
+
+    with open(authors_path) as f:
+        authors = json.load(f)
+    for author, rating in authors.items():
+        config.add_author(author, rating)
+
+    return config

--- a/scan_astroph/wordcounter.py
+++ b/scan_astroph/wordcounter.py
@@ -2,8 +2,10 @@ import json
 import os.path
 from collections import Counter
 from re import findall
+import argparse
+from pathlib import Path
 
-from . import config
+from .config import Config, find_configfile
 
 
 def _count_words(fname):
@@ -21,23 +23,19 @@ def most_common_words_in_file(fname, n, verbose=False):
     return counts
 
 
-def select_keywords(counts):
+def select_keywords(config: Config, counts):
     """Let the user rate or reject keywords"""
     # sort list by decreasing number of occurrence
     counts = dict(sorted(counts.items(), key=lambda item: item[1], reverse=True))
 
     print('for each suggested keyword, give a rating from 1 to 5 or reject it by pressing "enter".\nConclude by pressing "C".')
 
-    if os.path.exists('keywords.txt'):
-        # don't ask for previously added words
-        selected = config.read_keywords('keywords.txt')
-        for key in selected:
-            try:
-                counts.pop(key)
-            except KeyError:
-                pass
-    else:
-        selected = {}
+    # don't ask for previously added words
+    for key in config.keywords:
+        try:
+            counts.pop(key)
+        except KeyError:
+            pass
 
     for keyword in counts:
         while True:
@@ -45,29 +43,44 @@ def select_keywords(counts):
             usr_rating = input('{}: '.format(keyword))
             if (usr_rating == chr(27)) | (usr_rating.lower() == 'c'):
                 # escape was pressed
-                return selected
+                return config
             elif usr_rating == "":
                 break
             else:
                 try:
-                    selected[keyword] = int(usr_rating)
+                    config.add_keyword(keyword, int(usr_rating))
                     break
                 except ValueError:
                     print('rating must be an integer.')
                     continue
-    return selected
-
-def selected2file(selected, filename='keywords.txt'):
-    """write the selected keywords to a file."""
-    with open(filename, 'w') as file:
-        file.write(json.dumps(selected))
+    return config
 
 
 def main():
-    les_mis_file = input('path to file: ')
-    counts = most_common_words_in_file(les_mis_file, 200, verbose=False)
-    selected = select_keywords(counts)
-    selected2file(selected)
+    parser = argparse.ArgumentParser("Extract keywords from arbitrary text files")
+    parser.add_argument("-c", "--config", help="Config file to write keywords to")
+    parser.add_argument("file", help="Text file to scan for keywords")
+    args = parser.parse_args()
+
+    config = Config()
+
+    if args.config:
+        configfile = args.config
+    else:
+        try:
+            configfile = find_configfile()
+        except FileNotFoundError:
+            configfile = Path.home() / ".scan_astro-ph.conf"
+    try:
+        config.read(configfile)
+    except FileNotFoundError:
+        pass
+
+    counts = most_common_words_in_file(args.file, 200)
+    select_keywords(config, counts)
+
+    print("Writing config back to {}".format(configfile))
+    config.write(configfile, overwrite=True)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This PR implements the format which replaces the separate `keywords.txt` and `authors.txt` as discussed in #8.

Note: This PR is based on the `simske/refactor` branch, which is currently under review in #10, and will be ready to review after that. Until then the changes from refactor will also be shown here.

### TODO:
- [x] Implement ini-style configuration using standard library `configparser`
- [x] Implement conversion from old configuration style
- [ ] implement searching multiple paths for the config file
  - [x] locations on Unix
  - [ ] locations on Windows
- [x] Hook new implementation into `wordcounter`
- [ ] Add options other than authors and keywords to file
- [ ] Update README

### User facing changes:
There are now 3 more CLI arguments:
- `--config /path/to/configfile`: Load configfile from specified path
- `--default-config [/path/to/config]`: Write default config to `~/.scan_astro-ph.conf` / specified path
- `--config-convert [/path/to/new_config]`: convert `keywords.txt` and `authors.txt` to new format in `~/.scan_astro-ph.conf` / specified path

If no path is given as an CLI argument, the following paths are searched and the first one loaded:
- `$SCAN_ASTRO_PH_CONF`
- `~/.scan_astro-ph.conf`
- `$XDG_CONFIG_HOME/scan_astro-ph.conf` (`~/.config/scan_astro-ph.conf`)

The new format is as discussed in INI-style, e.g.
```
[authors]
Alpher = 1
Bethe = 2
Gamov = 3

[keywords]
star = 1
planet = 2
habitable = 3
```

`scan_astro-ph.wordcounter` has a new interface using argparse, it will update the config file it finds (using the above criteria), or will write a new one at `~/.scan_astro-ph.conf` (or the one specified on CLI).

### Implementation details.
The new implementation is a wrapper class `Config` around a `configparser.ConfigParser` object.
Properties are used to get an `dict[str, int]` output (as `configparser.ConfigParser` uses `str` internally).
Because the conversion is one way, there are extra methods to add new keywords and authors.